### PR TITLE
chore: update use method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@
 
 - 配置 `tsconfig.json`，确保 `compilerOptions.types` 中含有 `@dcloudio/types` 和 `@uni-helper/uni-app-types` 且 `include` 包含了对应的 `vue` 文件
 
-  <details>
+- 在 `tsconfig.json` 中配置 `vueCompilerOptions`，确保 `vueCompilerOptions` 中配置有 `nativeTags`.
+
+  <details open>
     <summary>1.6.0 <= <code>Vue Language Features (Volar)</code> & <code>vue-tsc</code></summary>
 
   ```json
@@ -48,7 +50,10 @@
     "compilerOptions": {
       "types": ["@dcloudio/types", "@uni-helper/uni-app-types"]
     },
-    "include": ["src/**/*.vue"]
+    "include": ["src/**/*.vue"],
+    "vueCompilerOptions": {
+      "nativeTags": ["block", "component", "template", "slot"]
+    }
   }
   ```
 


### PR DESCRIPTION
我的 `Volar` 版本是 1.8.1 在使用包的过程中发现，需要配置 `nativeTags` ts 类型才可以正常使用不报错，但是文档中并没有特别明确说明需要这个，所以我修改了一下使用文档并默认打开了配置详情。

我对这个属性并不是很了解，如果这个地方能加上这个配置的原因或者参考链接就更好了。[#46 ]这个 issues 是我提出的，可以同步关闭。

感谢。